### PR TITLE
Added `value` customization decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 *All the functions you need to program as if objects in JavaScript had value semantics, including comprehensive and highly customisible deep cloning and equality functions*
 
 <span class="badge-npmversion"><a href="https://npmjs.org/package/value-semantics" title="View this project on NPM"><img src="https://img.shields.io/npm/v/value-semantics.svg" alt="NPM version" /></a></span>
+<span class="badge-licence"><a href="https://opensource.org/license/mit" title="View this project's license"><img src="https://img.shields.io/npm/l/value-semantics.svg" alt="License" /></a></span>
 
 - [Value-Semantics](#value-semantics)
   - [What is `value-semantics`?](#what-is-value-semantics)
@@ -48,7 +49,8 @@ console.assert(equals(vector1, { x: 2, y: 3 }));
 
 // Customize `equals` and `clone` implementations on user-defined classes using 
 //   decorators
-@customize.value({ runConstructor: true }) // Customize `equals` and `clone` implementations simultaneously using the `@customize.value` decorator
+@customize.value({ runConstructor: true }) // Customize `equals` and `clone` implementations
+//   simultaneously using the `@customize.value` decorator
 class Rectangle {
   @clone.constructorParam private height: number; // Specify which properties 
   //   should be used as parameters for the cloning constructor
@@ -269,8 +271,8 @@ On a class with `'value'` equals semantics and `propDefault: include`, decoratin
 
 ```ts 
 @customize.value(
-  cloneSemantics?: CloneSemantics = 'deep' // cloneSemantics and equalsSemantics can be in either order
-  equalsSemantics?: EqualsSemantics = 'value'
+  cloneSemantics?: CloneSemantics = 'deep' // cloneSemantics and equalsSemantics can be
+  equalsSemantics?: EqualsSemantics = 'value' //    in either order
   options: CustomizeValueOptions = {}
 )
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
-# Value-Semantics: The JavaScript/TypeScript Value Semantics Toolkit
+# Value-Semantics
 
-***All the functions you need to program as if objects in JavaScript had value semantics, including comprehensive and highly customisible deep cloning and equality functions***
+**The JavaScript/TypeScript Value Semantics Toolkit**
+
+*All the functions you need to program as if objects in JavaScript had value semantics, including comprehensive and highly customisible deep cloning and equality functions*
+
+<span class="badge-npmversion"><a href="https://npmjs.org/package/value-semantics" title="View this project on NPM"><img src="https://img.shields.io/npm/v/value-semantics.svg" alt="NPM version" /></a></span>
+
+- [Value-Semantics](#value-semantics)
+  - [What is `value-semantics`?](#what-is-value-semantics)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Deep Cloning](#deep-cloning)
+    - [Value-Equality](#value-equality)
+    - [Customizing `clone` and `equals` Implementations](#customizing-clone-and-equals-implementations)
+      - [Customizing `clone` Implementations](#customizing-clone-implementations)
+        - [Constructor Parameter Decorator](#constructor-parameter-decorator)
+        - [Property Inclusion/Exclusion Decorators](#property-inclusionexclusion-decorators)
+      - [Customizing `equals` Implementations](#customizing-equals-implementations)
+        - [Property Inclusion/Exclusion Decorators](#property-inclusionexclusion-decorators-1)
+      - [Customizing `clone` and `equals` Implementations Simultaneously](#customizing-clone-and-equals-implementations-simultaneously)
+        - [Property Inclusion/Exclusion Decorators](#property-inclusionexclusion-decorators-2)
+  - [License](#license)
 
 ## What is `value-semantics`?
 
@@ -12,7 +32,8 @@ const lincolnBirthDate = new Date(1809, 1, 12);
 const darwinBirthDate = new Date(1809, 1, 12);
 console.assert(equals(lincolnBirthDate, darwinBirthDate));
 
-// Deep clone objects to avoid unwanted aliasing and to pass function parameters by value
+// Deep clone objects to avoid unwanted aliasing and to pass function parameters 
+//   by value
 type Vector = { x: number, y: number };
 function scale(vector: Vector, scale: number): Vector {
   vector.x *= scale;
@@ -25,13 +46,15 @@ const vector2 = scale(clone(vector1), 2);
 console.assert(equals(vector2, { x: 4, y: 6 }));
 console.assert(equals(vector1, { x: 2, y: 3 }));
 
-// Customize `equals` and `clone` implementations on user-defined classes using decorators
-@customize.equals()
-@customize.clone({ runConstructor: true })
+// Customize `equals` and `clone` implementations on user-defined classes using 
+//   decorators
+@customize.value({ runConstructor: true }) // Customize `equals` and `clone` implementations simultaneously using the `@customize.value` decorator
 class Rectangle {
-  @clone.constructorParam private height: number; // Specify which properties should be used as parameters for the cloning constructor
+  @clone.constructorParam private height: number; // Specify which properties 
+  //   should be used as parameters for the cloning constructor
   @clone.constructorParam private width: number;
-  @equals.exclude private orientation: number; // Exclude properties from cloning and/or equality comparison
+  @equals.exclude private orientation: number; // Exclude properties from cloning 
+  //   and/or equality comparison
 
   constructor(height: number, width: number) {
     this.height = height;
@@ -50,23 +73,11 @@ console.assert(rect1.orientation === 0);
 
 ```
 
+## Installation
+
+Run `npm install value-semantics` to install this library.
+
 ## Usage
-
-### Value-Equality
-
-```ts 
-equals(lhs: unknown, rhs: unknown): boolean 
-```
-
-Use the `equals` function to compare two JavaScript values for value-equality. Broadly speaking, this 
-function considers two objects equal when they both have the same prototype, same (enumerable, own) 
-property keys and the respective values for those keys are value-equal. This function can be customized for user-created classes, as discussed below.
-
-```ts
-const obj1 = { a: 1, b: [2, 3], c: new Date(2000, 0, 1), d: { e: 4 } };
-const obj2 = { d: { e: 4 }, c: new Date(2000, 0, 1), b: [2, 3], a: 1 };
-console.assert(equals(obj1, obj2));
-```
 
 ### Deep Cloning
 
@@ -89,6 +100,22 @@ console.assert(objcopy.d.e === 4);
 console.assert(obj.b[1] === 3);
 ```
 
+### Value-Equality
+
+```ts 
+equals(lhs: unknown, rhs: unknown): boolean 
+```
+
+Use the `equals` function to compare two JavaScript values for value-equality. Broadly speaking, this 
+function considers two objects equal when they both have the same prototype, same (enumerable, own) 
+property keys and the respective values for those keys are value-equal. This function can be customized for user-created classes, as discussed below.
+
+```ts
+const obj1 = { a: 1, b: [2, 3], c: new Date(2000, 0, 1), d: { e: 4 } };
+const obj2 = { d: { e: 4 }, c: new Date(2000, 0, 1), b: [2, 3], a: 1 };
+console.assert(equals(obj1, obj2));
+```
+
 ### Customizing `clone` and `equals` Implementations
 
 By a `clone` or `equals` implementation for a class, I mean the algorithm used to determine the results of calling `clone` or `equals` on an instance of that class. User-defined classes automatically have default implementations for `clone` and `equals`, where `equals` will compare an instance of a class equal to another value if and only if the other object is of the same class and has the same property values, and `clone` will return a new instance of the class with cloned property values. However, `clone` and `equals` implementations can be customized for user-defined classes using the decorators included in this toolkit.
@@ -96,7 +123,10 @@ By a `clone` or `equals` implementation for a class, I mean the algorithm used t
 #### Customizing `clone` Implementations
 
 ```ts 
-@customize.clone(semantics?: CloneSemantics = 'deep' | options?: CustomizeCloneOptions = {})
+@customize.clone(
+  semantics?: CloneSemantics = 'deep',
+  options?: CustomizeCloneOptions = {}
+)
 ```
 
 The `@customize.clone` class decorator can be used to customize the `clone` implementation for a class. When called with no arguments, or (one or both) default arguments, the decorated class will have the default implementation (i.e. `@customize.clone` will be a no-op). Otherwise, the `clone` implementation can be customized in the following ways:
@@ -136,10 +166,11 @@ class Graph {
 }
 
 const originalGraph = new Graph();
-const clonedGraph = clone(originalGraph); // calls Graph.prototype.constructor()
+const clonedGraph = clone(originalGraph); 
+  // calls Graph.prototype.constructor()
 ```
 
-`propDefault`: By default, and when this property is `'include'`, every (own, enumerable) property of an instance of the class will be copied over to its clones, unless otherwise specified using the `@clone.exclude` decorator described below. In contrast, when this property is `'exclude'`, no properties of an instance of the class will be copied over to its clones, unless otherwise specified using the `@clone.include` decorator described below.
+`propDefault`: By default, and when this property is `'include'`, every (own, enumerable) property of an instance of the class will be copied over to its clones, unless otherwise specified using the `@clone.exclude` (or `@value.exclude`) decorator described below. In contrast, when this property is `'exclude'`, no properties of an instance of the class will be copied over to its clones, unless otherwise specified using the `@clone.include` (or `@value.include`) decorator described below.
 
 ##### Constructor Parameter Decorator
 
@@ -163,10 +194,11 @@ class Person {
 }
 
 const originalPerson = new Person(178, 36);
-const clonedPerson = clone(originalPerson); // calls Person.prototype.constructor(178, 36)
+const clonedPerson = clone(originalPerson); 
+  // calls Person.prototype.constructor(178, 36)
 ```
 
-On a class which also has `propDefault: include`, labelling a class field with `@clone.constructorParam` will cause that field to be excluded from the clone implementation by default, unless the field is also labelled with `@clone.include`.
+On a class which also has `propDefault: include`, labelling a class field with `@clone.constructorParam` will cause that field to be excluded from the clone implementation by default, unless the field is also labelled with `@clone.include` (or `@value.include`).
 
 ##### Property Inclusion/Exclusion Decorators
 
@@ -177,21 +209,22 @@ On a class which also has `propDefault: include`, labelling a class field with `
 
 On a class with `'deep'` clone semantics and `propDefault: include`, decorating a class field with 
 `@clone.exclude` will override the default and exclude that field when cloning an instance of the class. On _any_ class with `'deep'` clone semantics, decorating a field with both `@clone.exclude` and 
-`@clone.include` will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, 
-`@clone.exclude` has no effect.
+`@clone.include` (or `@value.include`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@clone.exclude` has no effect.
 
 On a class with `'deep'` clone semantics and `propDefault: exclude`, decorating a class field with 
 `@clone.include` will override the default and include that field when cloning an instance of the class. On a class with `'deep'` clone semantics, `propDefault: include` and `runConstructor: true`, 
 decorating a `@clone.constructorParam` field with `@clone.include` in addition will override the 
 default and include that field when cloning an instance of the class (in addition to it being a 
 constructor parameter). On _any_ class with `'deep'` clone semantics, decorating a field with 
-both `@clone.exclude` and `@clone.include` will throw a `ValueSemanticsError` at runtime on class 
-definition. Otherwise, `@clone.include` has no effect.
+both `@clone.include` and `@clone.exclude` (or `@value.exclude`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@clone.include` has no effect.
 
 #### Customizing `equals` Implementations
 
 ```ts 
-@customize.equals(semantics?: EqualsSemantics = 'deep' | options?: CustomizeEqualsOptions = {})
+@customize.equals(
+  semantics?: EqualsSemantics = 'value',
+  options?: CustomizeEqualsOptions = {}
+)
 ```
 
 The `@customize.equals` class decorator can be used to customize the `equals` implementation for a class. When called with no arguments, or (one or both) default arguments, the decorated class will have the default implementation (i.e. `@customize.equals` will be a no-op). Otherwise, the `equals` implementation can be customized in the following ways:
@@ -200,7 +233,7 @@ The `@customize.equals` class decorator can be used to customize the `equals` im
 type EqualsSemantics = 'value' | 'ref';
 ```
 
-The `semantics` parameter can be used to customize the semantics of the class' `equals` implementation. There are 2 kinds of semantics that a `equals` implementation can have:
+The `semantics` parameter can be used to customize the semantics of the class' `equals` implementation. There are 2 kinds of semantics that an `equals` implementation can have:
 
 - `'value'`: This is the default semantics, where `equal` compares two instances of the class as equal if and only if they are value-equals (roughly, when they have the same property values).
 - `'ref'`: With this semantics, `equal` compares two instances of the class as equal if and only if they  refer to the same instance. In other words, on this semantics `equals` is the same as `===`.
@@ -215,10 +248,7 @@ If a class' `clone` implementation has `'value'` semantics, then it can be furth
 
 `propDefault`: By default, and when this property is `'include'`, every (own, enumerable) property of 
 an instance of the class will used to compare instances for equality, unless otherwise specified 
-using the `@equals.exclude` decorator described below. In constrast, when this property is `'exclude'`, 
-no properties of an instance of the class will be used to compare instances for equality (meaning all 
-instances of the class compare as equal), unless otherwise specified using the `@equals.include` 
-decorator described below.
+using the `@equals.exclude` (or `@value.exclude`) decorator described below. In constrast, when this property is `'exclude'`, no properties of an instance of the class will be used to compare instances for equality (meaning all instances of the class compare as equal), unless otherwise specified using the `@equals.include` (or `@value.include`) decorator described below.
 
 ##### Property Inclusion/Exclusion Decorators
 
@@ -229,10 +259,53 @@ decorator described below.
 
 On a class with `'value'` equals semantics and `propDefault: exclude`, decorating a class field with
 `@equals.include` will override the default and include that field when making equality comparisons.  On _any_ class with `'value'` equals semantics, decorating a field with both `@equals.include` and 
-`@equals.exclude` will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, 
-`@equals.include` has no effect.
+`@equals.exclude` (or `@value.exclude`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@equals.include` has no effect.
 
 On a class with `'value'` equals semantics and `propDefault: include`, decorating a class field with
 `@equals.exclude` will override the default and exclude that field when making equality comparisons.  On _any_ class with `'value'` equals semantics, decorating a field with both `@equals.exclude` and 
-`@equals.include` will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, 
-`@equals.exclude` has no effect.
+`@equals.include` (or `@value.include`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@equals.exclude` has no effect.
+
+#### Customizing `clone` and `equals` Implementations Simultaneously
+
+```ts 
+@customize.value(
+  cloneSemantics?: CloneSemantics = 'deep' // cloneSemantics and equalsSemantics can be in either order
+  equalsSemantics?: EqualsSemantics = 'value'
+  options: CustomizeValueOptions = {}
+)
+```
+
+It is possible to customize the implementations of both `equals` and `clone` on a class by decorating it with both `@customize.equals` and `@customize.clone`. However, to save space, this library also provides the `@customize.value` decorator, which customizes both of these functions at the same time. 
+
+When called with no arguments, or (one, two or all of the) default arguments, the decorated class will have the default implementations for `equals` and `clone` (i.e. `@customize.value` will be a no-op). Otherwise, the `equals` and `clone` implementations can be customized in the following ways:
+
+The `cloneSemantics` parameter can be used to customize the semantics of the class' `clone` implementation. The values that this parameter can take, and their meanings, are the same as for the `semantics` parameter of the `@customize.clone` decorator.
+
+The `equalsSemantics` parameter can be used to customize the semantics of the class' `equals` implementation. The values that this parameter can take, and their meanings, are the same as for the `semantics` parameter of the `@customize.equals` decorator.
+
+Note that the `cloneSemantics` and `equalsSemantics` can be provided in either order, although if one or both of them are present they must come before the `options` parameter (if it is present).
+
+```ts
+type CustomizeValueOptions = {
+  runConstructor?: boolean = false,
+  propDefault?: 'include' | 'exclude' = 'include'
+}
+```
+If a class' has `'deep' clone` and/or `'value' equals` semantics, then it can be further customized using the `options` parameter. Note that the `options` parameter cannot be passed for classes with `'ref' equals` and `'returnOriginal'` or `'errorOnClone' clone` semantics, as those semantics have no additional customization options. There are two properties which can be specified using the `options` parameter:
+
+`runConstructor`: The values that this property can take, and their meanings, are the same as for the `runConstructor` parameter of the `@customize.clone` decorator. As in the `@customize.clone` case, arguments for the constructor call can be specified using the `@clone.constructorParam` decorator described above, but note that there is no `@value.constructorParam` decorator. Note also that this property cannot be specified if the class has `'returnOriginal'` or `'errorOnClone' clone` semantics, as those semantics cannot involve running a constructor. This is true even if the class has `'value' equals` semantics, and can therefore take an `options` argument.
+
+`propDefault`: The values that this property can take, and their meanings, are the same as for the `propDefault` parameters of the `@customize.clone` and `@customize.equals` decorators. In other words, setting `propDefault` to `'include'` (`'exclude'`) is equivalent to setting `propDefault` to `'include'` (`'exclude'`) on both `@customize.clone` and `@customize.equals`. Note that `@customize.value` does not allow *different* values to be set for `propDefault` for `clone` and `equals` implementations. To do so, you would have to use seperate `@customize.equals` and `@customize.clone` decorators. Note also that, given a `propDefault: 'include'` value, decorating a class field with `@clone.constructorParam` will exclude that property from *cloning* but not *equality comparisons*. This can be overridden by either the `@clone.include` or `@value.include` decorators (but not `@equals.include`).
+
+##### Property Inclusion/Exclusion Decorators
+
+```ts 
+@value.include
+@value.exclude
+```
+
+Decorating a class field with `@value.include` (`@value.exclude`) has the same effect as decorating that field with both `@clone.include` and `@equals.include` (`@clone.exclude` and `@equals.exclude`). This means that, for example, decorating a class field with `@value.include` on a class decorated only with `@customize.equals({ propDefault: exclude })` will have the same effect has decorating that field with just `@equals.include` (i.e. the `@clone.include` aspect is a no-op). Any combination of field decorators which leads to a field being decorated with both `@clone.include` and `@clone.exclude`, and /or `@equals.include` and `@equals.exclude`, will throw a `ValueSemanticsError` at runtime on class definition. For example, decorating a field with `@value.exclude` and `@clone.include` will lead to such an error (even if the `@clone.exclude` aspect of `@value.exclude` is otherwise a no-op). On a class with `'deep'` clone semantics, `propDefault: include` and `runConstructor: true`, decorating a `@clone.constructorParam` field with `@value.include` in addition will override the default and include that field when cloning an instance of the class (in addition to it being a constructor parameter).
+
+## License
+
+MIT

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -4,9 +4,9 @@
 
 // * Value-Semantics: The JavaScript/TypeScript Value Semantics Toolkit *
 
-import { CLONE_SEMANTICS, CloneSemantics, customizeClone, CustomizeCloneOptions } from './clone';
+import { CLONE_SEMANTICS, CloneSemantics, customizeClone, CustomizeCloneOptions, clone } from './clone';
 import { ClassDecorator_, Constructor } from './common';
-import { customizeEquals, CustomizeEqualsOptions, EQUALS_SEMANTICS, EqualsSemantics } from './equals';
+import { customizeEquals, CustomizeEqualsOptions, EQUALS_SEMANTICS, EqualsSemantics, equals } from './equals';
 
 export { clone } from './clone';
 export { equals } from './equals';
@@ -122,4 +122,22 @@ export namespace customize {
       }
     }
   }
+}
+
+export namespace value {
+
+  export function include<C, V>(
+    target: undefined, context: ClassFieldDecoratorContext<C, V>
+  ): void {
+    clone.include(target, context);
+    equals.include(target, context);
+  }
+
+  export function exclude<C, V>(
+    target: undefined, context: ClassFieldDecoratorContext<C, V>
+  ): void {
+    clone.exclude(target, context);
+    equals.exclude(target, context);
+  }
+
 }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -4,11 +4,14 @@
 
 // * Value-Semantics: The JavaScript/TypeScript Value Semantics Toolkit *
 
-import { customizeClone } from './clone';
-import { customizeEquals } from './equals';
+import { CLONE_SEMANTICS, CloneSemantics, customizeClone, CustomizeCloneOptions } from './clone';
+import { ClassDecorator_, Constructor } from './common';
+import { customizeEquals, CustomizeEqualsOptions, EQUALS_SEMANTICS, EqualsSemantics } from './equals';
 
 export { clone } from './clone';
 export { equals } from './equals';
+
+type CustomizeValueOptions = CustomizeCloneOptions;
 
 /**
  * Class decorators which allow the class' `equals` and `clone` implementations to be customized.
@@ -17,4 +20,106 @@ export { equals } from './equals';
 export namespace customize {
   export const clone = customizeClone;
   export const equals = customizeEquals;
+
+  export function value<I extends object>(options?: CustomizeValueOptions): ClassDecorator_<I> // No Semantics
+  export function value<I extends object>( // Clone Semantics
+    cloneSemantics: 'deep', options?: CustomizeValueOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>( // Equals Semantics
+    equalsSemantics: 'value', options?: CustomizeValueOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    equalsSemantics: 'ref', options?: CustomizeCloneOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>( // Clone then Equals Semantics
+    cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    cloneSemantics: 'returnOriginal' | 'errorOnClone', 
+    equalsSemantics: 'value', 
+    options?: CustomizeEqualsOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    cloneSemantics: 'returnOriginal' | 'errorOnClone', 
+    equalsSemantics: 'ref'
+  ): ClassDecorator_<I>
+  export function value<I extends object>( // Equals then Clone Semantics
+    equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    equalsSemantics: 'value', 
+    cloneSemantics: 'returnOriginal' | 'errorOnClone', 
+    options?: CustomizeEqualsOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions
+  ): ClassDecorator_<I>
+  export function value<I extends object>(
+    equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone', 
+  ): ClassDecorator_<I>
+  export function value<I extends object>( // Overload
+    first?: CloneSemantics | EqualsSemantics | CustomizeValueOptions, 
+    second?: CloneSemantics | EqualsSemantics | CustomizeValueOptions,
+    third?: CustomizeValueOptions
+  ): ClassDecorator_<I> {
+    return function(constructor: Constructor<I>, context: ClassDecoratorContext): void {
+      let cloneSemantics: CloneSemantics = 'deep';
+      let equalsSemantics: EqualsSemantics = 'value';
+      let opts: CustomizeValueOptions = {};
+
+      if (typeof first === 'string') {
+        if (CLONE_SEMANTICS.includes(first as CloneSemantics)) {
+          cloneSemantics = first as CloneSemantics;
+        }
+        if (EQUALS_SEMANTICS.includes(first as EqualsSemantics)) {
+          equalsSemantics = first as EqualsSemantics;
+        }
+      } else if (first) {
+        opts = first;
+      }
+
+      if (typeof second === 'string') {
+        if (CLONE_SEMANTICS.includes(second as CloneSemantics)) {
+          cloneSemantics = second as CloneSemantics;
+        }
+        if (EQUALS_SEMANTICS.includes(second as EqualsSemantics)) {
+          equalsSemantics = second as EqualsSemantics;
+        }
+      } else if (second) {
+        opts = second;
+      }
+
+      if (third) {
+        opts = third;
+      }
+
+      const cloneOpts: CustomizeCloneOptions = { 
+        runConstructor: false, 
+        propDefault: 'include',
+        ...opts 
+      };
+      const equalsOpts: CustomizeEqualsOptions = { 
+        propDefault: 'include',
+        ...opts
+      };
+
+      if (cloneSemantics === 'deep') {
+        customize.clone('deep', cloneOpts)(constructor, context);
+      } else {
+        customize.clone(cloneSemantics)(constructor, context);
+      }
+
+      if (equalsSemantics === 'value') {
+        customize.equals('value', equalsOpts)(constructor, context);
+      } else {
+        customize.equals(equalsSemantics)(constructor, context);
+      }
+    }
+  }
 }

--- a/test/value.test.ts
+++ b/test/value.test.ts
@@ -1,0 +1,216 @@
+import { clone, customize, equals, value } from '../lib/main';
+import { expect, test } from 'vitest'
+
+// * Equals *
+
+test('equating class instances with value semantics', () => {
+  @customize.value()
+  class ClassExample { }
+  const instanceL = new ClassExample();
+  const instanceR = new ClassExample();
+  expect(equals(instanceL, instanceR)).toBeTruthy();
+  expect(equals({}, instanceR)).toBeFalsy();
+  expect(equals(instanceL, 0)).toBeFalsy();
+})
+
+test('equating class instances with class fields', () => {
+  @customize.value()
+  class Example {
+    constructor(public eg: string) { }
+  }
+  const instance0 = new Example('derive');
+  const instance1 = new Example('derive');
+  expect(equals(instance0, instance1)).toBeTruthy();
+})
+
+test('excludes a class field from comparison', () => {
+  @customize.value()
+  class ExcludeExample {
+    @value.exclude public excludeField: string;
+    constructor(excludeField: string) {
+      this.excludeField = excludeField;
+    }
+  }
+  const instanceL = new ExcludeExample('excl0');
+  const instanceR = new ExcludeExample('excl1');
+  expect(equals(instanceL, instanceR)).toBeTruthy();
+})
+
+test('includes a class field in comparison', () => {
+  @customize.value({ propDefault: 'exclude' })
+  class IncludeExample {
+    @value.include public includeField: string;
+    constructor(includeField: string) {
+      this.includeField = includeField;
+    }
+  }
+  const instanceL = new IncludeExample('incl0');
+  const instanceR = new IncludeExample('incl1');
+  expect(equals(instanceL, instanceR)).toBeFalsy();
+})
+
+test('excludes all properties in comparison', () => {
+  @customize.value('value', { propDefault: 'exclude' })
+  class ExcludeAllExample {
+    public excludeField: string;
+    constructor(excludeField: string) {
+      this.excludeField = excludeField;
+    }
+  }
+  const instance0 = new ExcludeAllExample('excl0');
+  const instance1 = new ExcludeAllExample('excl1');
+  expect(equals(instance0, instance1)).toBeTruthy();
+})
+
+test('equating class instances with reference semantics', () => {
+  @customize.value('ref')
+  class StrictEqualsExample { }
+  const instanceL = new StrictEqualsExample();
+  const instanceR = new StrictEqualsExample();
+  expect(equals(instanceL, instanceR)).toBeFalsy();
+})
+
+// * Clone *
+
+// Non-constructor classes
+
+test('clones a class instance without using a constructor function', () => {
+  @customize.value()
+  class ClassExample { }
+  const instance = new ClassExample();
+  const instanceClone = clone(instance);
+  expect(instanceClone instanceof ClassExample).toBeTruthy();
+})
+
+test('excludes a class field from cloning', () => {
+  @customize.value()
+  class ExcludeExample {
+    @value.exclude public excludeField: string;
+    constructor(excludeField: string) {
+      this.excludeField = excludeField;
+    }
+  }
+  const instance = new ExcludeExample('excl');
+  const instanceClone = clone(instance);
+  expect(instanceClone.excludeField).toBeUndefined();
+})
+
+test('includes a class field in cloning', () => {
+  @customize.value({ propDefault: 'exclude' })
+  class IncludeExample {
+    @value.include public includeField: string;
+    constructor(includeField: string) {
+      this.includeField = includeField;
+    }
+  }
+  const instance = new IncludeExample('incl');
+  const instanceClone = clone(instance);
+  expect(instanceClone.includeField).toBe('incl');
+})
+
+test('excludes all properties in cloning', () => {
+  @customize.value({ propDefault: 'exclude' })
+  class ExcludeAllExample {
+    public excludeField: string;
+    constructor(excludeField: string) {
+      this.excludeField = excludeField;
+    }
+  }
+  const instance = new ExcludeAllExample('excl');
+  const instanceClone = clone(instance);
+  expect(instanceClone.excludeField).toBeUndefined();
+})
+
+test('error: cannot clone errorOnClone class', () => {
+  expect(() => {
+    @customize.value('errorOnClone')
+    class NoCloneExample { }
+    const instance = new NoCloneExample();
+    const copy = clone(instance); //Needed to throw
+  }).toThrowError(
+    /^Instances of class NoCloneExample cannot be cloned$/
+  )
+})
+
+test('changing cloned class instances', () => {
+  @customize.value()
+  class Example {
+    constructor(public eg: string) { }
+  }
+
+  const original = new Example('test');
+  const copy = clone(original);
+
+  expect(copy instanceof Example).toBeTruthy();
+  expect(copy.eg).toBe('test');
+  copy.eg = 'new';
+  expect(original.eg).toBe('test');
+  expect(copy.eg).toBe('new');
+  original.eg = 'old';
+  expect(original.eg).toBe('old');
+  expect(copy.eg).toBe('new');
+})
+
+// Constructor Classes
+
+test('clones a class instance using a constructor function', () => {
+  @customize.value({runConstructor: true})
+  class ConstructorExample {
+    constructor() { }
+  }
+  const instance = new ConstructorExample();
+  const instanceClone = clone(instance);
+  expect(instanceClone instanceof ConstructorExample).toBeTruthy();
+})
+
+test('clones a class instance using a constructor function with arguments', () => {
+  @customize.value({ runConstructor: true })
+  class ConstructorExample {
+    @clone.constructorParam public constructorField: string;
+    constructor(constructorField: string) {
+      if (constructorField === undefined) {
+        throw new Error('Constructor not run')
+      }
+      this.constructorField = constructorField;
+    }
+  }
+  const instance = new ConstructorExample('ctor');
+  const instanceClone = clone(instance);
+  expect(instanceClone instanceof ConstructorExample).toBeTruthy();
+  expect(instanceClone.constructorField).toBe('ctor');
+})
+
+test('subclass inherits clone implementation', () => {
+  @customize.value()
+  class ExcludeExample {
+    @value.exclude public excludeField: string;
+    constructor(excludeField: string) {
+      this.excludeField = excludeField;
+    }
+  }
+
+  class ExtendExample extends ExcludeExample { }
+  const instance = new ExtendExample('excl');
+  const instanceClone = clone(instance);
+  expect(instanceClone.excludeField).toBeUndefined();
+})
+
+// * Equals and Clone *
+
+test('equating and cloning class instances with value and deep clone semantics', () => {
+  @customize.value('deep', 'value', { runConstructor: false })
+  class ValueClassExample { }
+  const instanceL = new ValueClassExample();
+  const instanceR = new ValueClassExample();
+  expect(equals(instanceL, instanceR)).toBeTruthy();
+  expect(equals({}, instanceR)).toBeFalsy();
+  expect(equals(instanceL, 0)).toBeFalsy();
+})
+
+test('equating and cloning class instances with ref and returnOriginal semantics', () => {
+  @customize.value('ref', 'returnOriginal')
+  class ValueClassExample { }
+  const instanceL = new ValueClassExample();
+  const instanceR = new ValueClassExample();
+  expect(equals(instanceL, instanceR)).toBeFalsy();
+})


### PR DESCRIPTION
Adds `@customize.value` class decorator which combines `@customize.clone` and `@customize.equals` into one.

Adds `@value.include` and `@value.exclude` class field decorators which combine `@clone.include` with `@equals.include` and `@clone.exclude` with `@equals.exclude`, respectively.