### PR TITLE
Implement 'iterate' semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,4 @@ dist
 temp
 
 # Development
-dev/playground.cjs
+dev/build

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist
 
 # API Extractor
 temp
+
+# Development
+dev/playground.cjs

--- a/README.md
+++ b/README.md
@@ -14,14 +14,7 @@
   - [Usage](#usage)
     - [Deep Cloning](#deep-cloning)
     - [Value-Equality](#value-equality)
-    - [Customizing `clone` and `equals` Implementations](#customizing-clone-and-equals-implementations)
-      - [Customizing `clone` Implementations](#customizing-clone-implementations)
-        - [Constructor Parameter Decorator](#constructor-parameter-decorator)
-        - [Property Inclusion/Exclusion Decorators](#property-inclusionexclusion-decorators)
-      - [Customizing `equals` Implementations](#customizing-equals-implementations)
-        - [Property Inclusion/Exclusion Decorators](#property-inclusionexclusion-decorators-1)
-      - [Customizing `clone` and `equals` Implementations Simultaneously](#customizing-clone-and-equals-implementations-simultaneously)
-        - [Property Inclusion/Exclusion Decorators](#property-inclusionexclusion-decorators-2)
+    - [Customization](#customization)
   - [License](#license)
 
 ## What is `value-semantics`?
@@ -119,195 +112,18 @@ const obj2 = { d: { e: 4 }, c: new Date(2000, 0, 1), b: [2, 3], a: 1 };
 console.assert(equals(obj1, obj2));
 ```
 
-### Customizing `clone` and `equals` Implementations
+### Customization 
 
-By a `clone` or `equals` implementation for a class, I mean the algorithm used to determine the results of calling `clone` or `equals` on an instance of that class. User-defined classes automatically have default implementations for `clone` and `equals`, where `equals` will compare an instance of a class equal to another value if and only if the other object is of the same class and has the same property values, and `clone` will return a new instance of the class with cloned property values. However, `clone` and `equals` implementations can be customized for user-defined classes using the decorators included in this toolkit.
+By default, the result of applying `clone` or `equals` to an instance of a user-defined class is the same as applying it to any other (non-exotic) object: i.e. `equals` will compare an instance of a class equal to another value if and only if the other value is an object of the same class with the same property keys and values, and `clone` will return a new instance of the class with cloned property values.
 
-#### Customizing `clone` Implementations
+It is, however, possible to customize these results for user-defined classes using decorators included in value-semantics. The following behaviors can be customized for instances of a user-defined class:
+- Particular properties can be excluded from cloning and equality comparison, for both `clone` and/or `equals`.
+- All properties can be excluded from cloning and equality comparison by default, and certain properties can then be included, for both `clone` and/or `equals`. 
+- `clone` can be changed to return the original instance, or to throw an error.
+- `clone` can be changed to run the class' constructor, and arguments can be specified for the constructor (where those arguments are provided by particular properties of the original).
+- `equals` can be changed to compare instances by reference-equality.
 
-```ts 
-@customize.clone(
-  semantics?: CloneSemantics = 'deep',
-  options?: CustomizeCloneOptions = {}
-)
-```
-
-The `@customize.clone` class decorator can be used to customize the `clone` implementation for a class. When called with no arguments, or (one or both) default arguments, the decorated class will have the default implementation (i.e. `@customize.clone` will be a no-op). Otherwise, the `clone` implementation can be customized in the following ways:
-
-```ts
-type CloneSemantics = 'deep' | 'returnOriginal' | 'errorOnClone';
-```
-
-The `semantics` parameter can be used to customize the semantics of the class' `clone` implementation. There are 3 kinds of semantics that a `clone` implementation can have:
-
-- `'deep'`: This is the default semantics, where `clone` returns a deep clone of the class instance.
-- `'returnOriginal'`: With this semantics, `clone` will return the original class instance without any cloning being performed.
-- `'errorOnClone'`: With this semantics, `clone` will throw a `ValueSemanticsError` at runtime when applied to a instance of this class.
-
-```ts
-type CustomizeCloneOptions = {
-  runConstructor?: boolean = false,
-  propDefault?: 'include' | 'exclude' = 'include'
-}
-```
-
-If a class' `clone` implementation has `'deep'` semantics, then it can be further customized using the `options` parameter. The `options` parameter cannot be passed for classes with `'returnOriginal'` or `'errorOnClone'` semantics, as those semantics have no additional customization options. There are two properties which can be specified using the `options` parameter:
-
-`runConstructor`: By default, and when this property is `false`, clones of a class instance are created by `Object.create()`, before the instance's properties are copied over. When this property is `true`, clones of a class instance are created by the class' constructor. Arguments for the constructor call can be specified using the `@clone.constructorParam` decorator described below, otherwise the constructor will run without any arguments. 
-
-For example:
-```ts
-@customize.clone({ runConstructor: true }) 
-class Graph {
-  public nodes: Nodes[];
-  public edges: Edge[];
-
-  constructor() {
-    this.nodes = [];
-    this.edges = [];
-  }
-}
-
-const originalGraph = new Graph();
-const clonedGraph = clone(originalGraph); 
-  // calls Graph.prototype.constructor()
-```
-
-`propDefault`: By default, and when this property is `'include'`, every (own, enumerable) property of an instance of the class will be copied over to its clones, unless otherwise specified using the `@clone.exclude` (or `@value.exclude`) decorator described below. In contrast, when this property is `'exclude'`, no properties of an instance of the class will be copied over to its clones, unless otherwise specified using the `@clone.include` (or `@value.include`) decorator described below.
-
-##### Constructor Parameter Decorator
-
-```ts 
-@clone.constructorParam
-```
-
-On a class with `'deep'` clone semantics and `runConstructor: true`, labelling a class field with `@clone.constructorParam` means that the value of that field will be provided to the constructor as an argument when cloning an instance of the class. On any other class, `@clone.constructorParam` has no effect. If multiple fields are labelled with `@clone.constructorParam`, they will be provided to the constructor in order, top to bottom.
-
-For example:
-```ts
-@customize.clone({ runConstructor: true }) 
-class Person {
-  @clone.constructorParam private height: number;
-  @clone.constructorParam private age: number;
-
-  constructor(height: number, age: number) {
-    this.height = height;
-    this.age = age;
-  }
-}
-
-const originalPerson = new Person(178, 36);
-const clonedPerson = clone(originalPerson); 
-  // calls Person.prototype.constructor(178, 36)
-```
-
-On a class which also has `propDefault: include`, labelling a class field with `@clone.constructorParam` will cause that field to be excluded from the clone implementation by default, unless the field is also labelled with `@clone.include` (or `@value.include`).
-
-##### Property Inclusion/Exclusion Decorators
-
-```ts
-@clone.exclude
-@clone.include
-```
-
-On a class with `'deep'` clone semantics and `propDefault: include`, decorating a class field with 
-`@clone.exclude` will override the default and exclude that field when cloning an instance of the class. On _any_ class with `'deep'` clone semantics, decorating a field with both `@clone.exclude` and 
-`@clone.include` (or `@value.include`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@clone.exclude` has no effect.
-
-On a class with `'deep'` clone semantics and `propDefault: exclude`, decorating a class field with 
-`@clone.include` will override the default and include that field when cloning an instance of the class. On a class with `'deep'` clone semantics, `propDefault: include` and `runConstructor: true`, 
-decorating a `@clone.constructorParam` field with `@clone.include` in addition will override the 
-default and include that field when cloning an instance of the class (in addition to it being a 
-constructor parameter). On _any_ class with `'deep'` clone semantics, decorating a field with 
-both `@clone.include` and `@clone.exclude` (or `@value.exclude`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@clone.include` has no effect.
-
-#### Customizing `equals` Implementations
-
-```ts 
-@customize.equals(
-  semantics?: EqualsSemantics = 'value',
-  options?: CustomizeEqualsOptions = {}
-)
-```
-
-The `@customize.equals` class decorator can be used to customize the `equals` implementation for a class. When called with no arguments, or (one or both) default arguments, the decorated class will have the default implementation (i.e. `@customize.equals` will be a no-op). Otherwise, the `equals` implementation can be customized in the following ways:
-
-```ts
-type EqualsSemantics = 'value' | 'ref';
-```
-
-The `semantics` parameter can be used to customize the semantics of the class' `equals` implementation. There are 2 kinds of semantics that an `equals` implementation can have:
-
-- `'value'`: This is the default semantics, where `equal` compares two instances of the class as equal if and only if they are value-equals (roughly, when they have the same property values).
-- `'ref'`: With this semantics, `equal` compares two instances of the class as equal if and only if they  refer to the same instance. In other words, on this semantics `equals` is the same as `===`.
-
-```ts
-type CustomizeEqualsOptions = {
-  propDefault?: 'include' | 'exclude' = 'include'
-}
-```
-
-If a class' `clone` implementation has `'value'` semantics, then it can be further customized using the `options` parameter. The `options` parameter cannot be passed for classes with `'ref'` semantics, as it has no additional customization options. There is one property which can be specified using the `options` parameter:
-
-`propDefault`: By default, and when this property is `'include'`, every (own, enumerable) property of 
-an instance of the class will used to compare instances for equality, unless otherwise specified 
-using the `@equals.exclude` (or `@value.exclude`) decorator described below. In constrast, when this property is `'exclude'`, no properties of an instance of the class will be used to compare instances for equality (meaning all instances of the class compare as equal), unless otherwise specified using the `@equals.include` (or `@value.include`) decorator described below.
-
-##### Property Inclusion/Exclusion Decorators
-
-```ts 
-@equals.include
-@equals.exclude
-```
-
-On a class with `'value'` equals semantics and `propDefault: exclude`, decorating a class field with
-`@equals.include` will override the default and include that field when making equality comparisons.  On _any_ class with `'value'` equals semantics, decorating a field with both `@equals.include` and 
-`@equals.exclude` (or `@value.exclude`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@equals.include` has no effect.
-
-On a class with `'value'` equals semantics and `propDefault: include`, decorating a class field with
-`@equals.exclude` will override the default and exclude that field when making equality comparisons.  On _any_ class with `'value'` equals semantics, decorating a field with both `@equals.exclude` and 
-`@equals.include` (or `@value.include`) will throw a `ValueSemanticsError` at runtime on class definition. Otherwise, `@equals.exclude` has no effect.
-
-#### Customizing `clone` and `equals` Implementations Simultaneously
-
-```ts 
-@customize.value(
-  cloneSemantics?: CloneSemantics = 'deep' // cloneSemantics and equalsSemantics can be
-  equalsSemantics?: EqualsSemantics = 'value' //    in either order
-  options: CustomizeValueOptions = {}
-)
-```
-
-It is possible to customize the implementations of both `equals` and `clone` on a class by decorating it with both `@customize.equals` and `@customize.clone`. However, to save space, this library also provides the `@customize.value` decorator, which customizes both of these functions at the same time. 
-
-When called with no arguments, or (one, two or all of the) default arguments, the decorated class will have the default implementations for `equals` and `clone` (i.e. `@customize.value` will be a no-op). Otherwise, the `equals` and `clone` implementations can be customized in the following ways:
-
-The `cloneSemantics` parameter can be used to customize the semantics of the class' `clone` implementation. The values that this parameter can take, and their meanings, are the same as for the `semantics` parameter of the `@customize.clone` decorator.
-
-The `equalsSemantics` parameter can be used to customize the semantics of the class' `equals` implementation. The values that this parameter can take, and their meanings, are the same as for the `semantics` parameter of the `@customize.equals` decorator.
-
-Note that the `cloneSemantics` and `equalsSemantics` can be provided in either order, although if one or both of them are present they must come before the `options` parameter (if it is present).
-
-```ts
-type CustomizeValueOptions = {
-  runConstructor?: boolean = false,
-  propDefault?: 'include' | 'exclude' = 'include'
-}
-```
-If a class' has `'deep' clone` and/or `'value' equals` semantics, then it can be further customized using the `options` parameter. Note that the `options` parameter cannot be passed for classes with `'ref' equals` and `'returnOriginal'` or `'errorOnClone' clone` semantics, as those semantics have no additional customization options. There are two properties which can be specified using the `options` parameter:
-
-`runConstructor`: The values that this property can take, and their meanings, are the same as for the `runConstructor` parameter of the `@customize.clone` decorator. As in the `@customize.clone` case, arguments for the constructor call can be specified using the `@clone.constructorParam` decorator described above, but note that there is no `@value.constructorParam` decorator. Note also that this property cannot be specified if the class has `'returnOriginal'` or `'errorOnClone' clone` semantics, as those semantics cannot involve running a constructor. This is true even if the class has `'value' equals` semantics, and can therefore take an `options` argument.
-
-`propDefault`: The values that this property can take, and their meanings, are the same as for the `propDefault` parameters of the `@customize.clone` and `@customize.equals` decorators. In other words, setting `propDefault` to `'include'` (`'exclude'`) is equivalent to setting `propDefault` to `'include'` (`'exclude'`) on both `@customize.clone` and `@customize.equals`. Note that `@customize.value` does not allow *different* values to be set for `propDefault` for `clone` and `equals` implementations. To do so, you would have to use seperate `@customize.equals` and `@customize.clone` decorators. Note also that, given a `propDefault: 'include'` value, decorating a class field with `@clone.constructorParam` will exclude that property from *cloning* but not *equality comparisons*. This can be overridden by either the `@clone.include` or `@value.include` decorators (but not `@equals.include`).
-
-##### Property Inclusion/Exclusion Decorators
-
-```ts 
-@value.include
-@value.exclude
-```
-
-Decorating a class field with `@value.include` (`@value.exclude`) has the same effect as decorating that field with both `@clone.include` and `@equals.include` (`@clone.exclude` and `@equals.exclude`). This means that, for example, decorating a class field with `@value.include` on a class decorated only with `@customize.equals({ propDefault: exclude })` will have the same effect has decorating that field with just `@equals.include` (i.e. the `@clone.include` aspect is a no-op). Any combination of field decorators which leads to a field being decorated with both `@clone.include` and `@clone.exclude`, and /or `@equals.include` and `@equals.exclude`, will throw a `ValueSemanticsError` at runtime on class definition. For example, decorating a field with `@value.exclude` and `@clone.include` will lead to such an error (even if the `@clone.exclude` aspect of `@value.exclude` is otherwise a no-op). On a class with `'deep'` clone semantics, `propDefault: include` and `runConstructor: true`, decorating a `@clone.constructorParam` field with `@value.include` in addition will override the default and include that field when cloning an instance of the class (in addition to it being a constructor parameter).
+See (the wiki)[https://github.com/simonvarey/value-semantics/wiki/Customization] for API documentation for the customization decorators. Currently, the results of applying `clone` or `equals` to instances of built-in classes, exotic objects, and object literals cannot be customized.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <span class="badge-npmversion"><a href="https://npmjs.org/package/value-semantics" title="View this project on NPM"><img src="https://img.shields.io/npm/v/value-semantics.svg" alt="NPM version" /></a></span>
 <span class="badge-licence"><a href="https://opensource.org/license/mit" title="View this project's license"><img src="https://img.shields.io/npm/l/value-semantics.svg" alt="License" /></a></span>
+![Statements](https://img.shields.io/badge/statements-99.71%25-brightgreen.svg?style=flat)
 
 - [Value-Semantics](#value-semantics)
   - [What is `value-semantics`?](#what-is-value-semantics)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ By default, the result of applying `clone` or `equals` to an instance of a user-
 
 It is, however, possible to customize these results for user-defined classes using decorators included in value-semantics. The following behaviors can be customized for instances of a user-defined class:
 - Particular properties can be excluded from cloning and equality comparison, for both `clone` and/or `equals`.
-- All properties can be excluded from cloning and equality comparison by default, and certain properties can then be included, for both `clone` and/or `equals`. 
+- All properties can be excluded from cloning and equality comparison by default, and certain properties can then be included, for both `clone` and/or `equals`.
+- Instances can be cloned and/or compared for equality using their iterator property instead.
 - `clone` can be changed to return the original instance, or to throw an error.
 - `clone` can be changed to run the class' constructor, and arguments can be specified for the constructor (where those arguments are provided by particular properties of the original).
 - `equals` can be changed to compare instances by reference-equality.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     - [Deep Cloning](#deep-cloning)
     - [Value-Equality](#value-equality)
     - [Customization](#customization)
+  - [Development](#development)
   - [License](#license)
 
 ## What is `value-semantics`?
@@ -124,6 +125,12 @@ It is, however, possible to customize these results for user-defined classes usi
 - `equals` can be changed to compare instances by reference-equality.
 
 See (the wiki)[https://github.com/simonvarey/value-semantics/wiki/Customization] for API documentation for the customization decorators. Currently, the results of applying `clone` or `equals` to instances of built-in classes, exotic objects, and object literals cannot be customized.
+
+## Development
+
+Use `npm i` and then `npm run build` to build the library.
+
+`value-semantics` contains a playground at `dev/playground.ts` which you can use to test out the functionality of the toolbox. (Note that you need to build the library once before using the playground). Use `npm run playground` to run the playground. The playground can also be used to test out changes to the toolbox, by re-building library after making the changes.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The JavaScript/TypeScript Value Semantics Toolkit**
 
-*All the functions you need to program as if objects in JavaScript had value semantics, including comprehensive and highly customisible deep cloning and equality functions*
+> All the functions you need to program as if objects in JavaScript had value semantics, including comprehensive and highly customisible deep cloning and equality functions
 
 <span class="badge-npmversion"><a href="https://npmjs.org/package/value-semantics" title="View this project on NPM"><img src="https://img.shields.io/npm/v/value-semantics.svg" alt="NPM version" /></a></span>
 <span class="badge-licence"><a href="https://opensource.org/license/mit" title="View this project's license"><img src="https://img.shields.io/npm/l/value-semantics.svg" alt="License" /></a></span>

--- a/dev/playground.cts
+++ b/dev/playground.cts
@@ -1,0 +1,4 @@
+import { clone, equals, customize } from '../dist/value-semantics.js';
+
+// This is the value-semantics playground. It has access to all the functionality of value-semantics.
+// Enter test code here and run it with `npm run playground`.

--- a/dev/playground.ts
+++ b/dev/playground.ts
@@ -1,4 +1,4 @@
-import { clone, equals, customize } from '../dist/value-semantics.js';
+import { clone, equals, customize } from '../dist/value-semantics';
 
 // This is the value-semantics playground. It has access to all the functionality of value-semantics.
 // Enter test code here and run it with `npm run playground`.

--- a/dev/playground.vite.config.ts
+++ b/dev/playground.vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: './dev/playground.ts',
+      formats: [ 'es' ],
+      fileName: 'playground'
+    },
+    outDir: './dev/build'
+  }
+})

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -13,7 +13,7 @@
 
     /* Language and Environment */
     "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ESNext", "DOM"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["ESNext", "DOM"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["playground.cts"],
+  "include": ["playground.ts"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
@@ -50,9 +50,9 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": false,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "emitDeclarationOnly": true,                         /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -1,0 +1,110 @@
+{
+  "include": ["playground.cts"],
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["ESNext", "DOM"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "ESNext",                                  /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "Bundler",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    // "esModuleInterop": false,                         /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    // "forceConsistentCasingInFileNames": true,         /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/etc/value-semantics.api.md
+++ b/etc/value-semantics.api.md
@@ -27,6 +27,43 @@ export namespace customize {
     //
     // (undocumented)
     equals: typeof customizeEquals;
+    // Warning: (ae-forgotten-export) The symbol "CustomizeValueOptions" needs to be exported by the entry point main.d.ts
+    // Warning: (ae-forgotten-export) The symbol "ClassDecorator_" needs to be exported by the entry point main.d.ts
+    //
+    // (undocumented)
+    export function value<I extends object>(options?: CustomizeValueOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(// Clone Semantics
+    cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    // Warning: (ae-forgotten-export) The symbol "CustomizeEqualsOptions" needs to be exported by the entry point main.d.ts
+    //
+    // (undocumented)
+    export function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(// Equals Semantics
+    equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    // Warning: (ae-forgotten-export) The symbol "CustomizeCloneOptions" needs to be exported by the entry point main.d.ts
+    //
+    // (undocumented)
+    export function value<I extends object>(equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(// Clone then Equals Semantics
+    cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'ref'): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(// Equals then Clone Semantics
+    equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(equalsSemantics: 'value', cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    // (undocumented)
+    export function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<I>;
 }
 
 // @public
@@ -38,6 +75,14 @@ export namespace equals {
     export function exclude<C, V>(_target: undefined, context: ClassFieldDecoratorContext<C, V>): void;
     // (undocumented)
     export function include<C, V>(_target: undefined, context: ClassFieldDecoratorContext<C, V>): void;
+}
+
+// @public (undocumented)
+export namespace value {
+    // (undocumented)
+    export function exclude<C, V>(target: undefined, context: ClassFieldDecoratorContext<C, V>): void;
+    // (undocumented)
+    export function include<C, V>(target: undefined, context: ClassFieldDecoratorContext<C, V>): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/etc/value-semantics.api.md
+++ b/etc/value-semantics.api.md
@@ -27,43 +27,44 @@ export namespace customize {
     //
     // (undocumented)
     equals: typeof customizeEquals;
+    // Warning: (ae-forgotten-export) The symbol "ConstructorFunc" needs to be exported by the entry point main.d.ts
     // Warning: (ae-forgotten-export) The symbol "CustomizeValueOptions" needs to be exported by the entry point main.d.ts
     // Warning: (ae-forgotten-export) The symbol "ClassDecorator_" needs to be exported by the entry point main.d.ts
     //
     // (undocumented)
-    export function value<I extends object>(options?: CustomizeValueOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(options?: CustomizeValueOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(// Clone Semantics
-    cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(// Clone Semantics
+    cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<C>;
     // Warning: (ae-forgotten-export) The symbol "CustomizeEqualsOptions" needs to be exported by the entry point main.d.ts
     //
     // (undocumented)
-    export function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(// Equals Semantics
-    equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(// Equals Semantics
+    equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<C>;
     // Warning: (ae-forgotten-export) The symbol "CustomizeCloneOptions" needs to be exported by the entry point main.d.ts
     //
     // (undocumented)
-    export function value<I extends object>(equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(// Clone then Equals Semantics
-    cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(// Clone then Equals Semantics
+    cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'ref'): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'ref'): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(// Equals then Clone Semantics
-    equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(// Equals then Clone Semantics
+    equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(equalsSemantics: 'value', cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(equalsSemantics: 'value', cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<C>;
     // (undocumented)
-    export function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<I>;
+    export function value<C extends ConstructorFunc>(equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<C>;
 }
 
 // @public

--- a/lib/clone.ts
+++ b/lib/clone.ts
@@ -269,7 +269,7 @@ export function customizeClone<I extends object>(
       const target = runConstructor ? constructTarget(this) : createTarget(this);
       visited.set(this, target);
       for (const member of this) {
-        this[addMethod](clonecyc(member, visited));
+        target[addMethod](clonecyc(member, visited));
       }
       return target;
     }

--- a/lib/clone.ts
+++ b/lib/clone.ts
@@ -8,10 +8,9 @@
 
 // Imports
 
-import { CLONE_EXCLUDE_PROPS, CLONE_INCLUDE_PROPS, Constructor, CLONE_METHOD, TYPED_ARRAYS, PropKey, 
+import { CLONE_EXCLUDE_PROPS, CLONE_INCLUDE_PROPS, CLONE_METHOD, TYPED_ARRAYS, PropKey, 
   getAllKeys, getKeys, getMeta, META_NOT_FOUND, CloneMethodFunc, setMeta, CONSTRUCTOR_PROPS, 
-  ValueSemanticsError, CloneVisited, ClassDecorator_,
-  ConstructorFunc} from "./common";
+  ValueSemanticsError, CloneVisited, ClassDecorator_, Constructor } from "./common";
 
 // Symbols
 
@@ -21,8 +20,10 @@ export const ERROR_ON_CLONE = Symbol.for('error-on-clone');
 
 // Object Construction
 
+type ConstructorOf<Instance> = { new(...args: any[]): Instance; };
+
 function constructTarget<T extends object>(source: T): T {
-  const constructor = source.constructor as Constructor<T>;
+  const constructor = source.constructor as ConstructorOf<T>;
   let constructorKeys = getMeta(source, CONSTRUCTOR_PROPS);
   if (constructorKeys === META_NOT_FOUND) {
     constructorKeys = [];
@@ -62,7 +63,7 @@ export function copyProps<T extends Object>(
 
 // * Clone Methods on Built-ins *
 
-const defineCloneMethod = <C extends ConstructorFunc>(
+const defineCloneMethod = <C extends Constructor>(
   target: C, value: CloneMethodFunc<InstanceType<C>>
 ) => {
   setMeta(target, CLONE_METHOD, value);
@@ -132,7 +133,7 @@ for (const TypedArray of TYPED_ARRAYS) {
   );
 }
 
-function defineCloneReturnOriginal<C extends ConstructorFunc>(proto: C) {
+function defineCloneReturnOriginal<C extends Constructor>(proto: C) {
   defineCloneMethod(proto, function(this: InstanceType<C>, visited: CloneVisited): InstanceType<C> {
     visited.set(this, this);
     return this;
@@ -152,7 +153,7 @@ setMeta(Symbol, CLONE_METHOD, function(this: Symbol, visited: CloneVisited): Sym
   return this;
 })
 
-function defineErrorOnClone(proto: ConstructorFunc): void {
+function defineErrorOnClone(proto: Constructor): void {
   setMeta(proto, ERROR_ON_CLONE, proto.name);
 }
 
@@ -222,17 +223,17 @@ export type IterateCloneOptions = {
 
 // Class Decorator
 
-export function customizeClone<C extends ConstructorFunc>(options?: CustomizeCloneOptions): ClassDecorator_<C>
-export function customizeClone<C extends ConstructorFunc>(
+export function customizeClone<C extends Constructor>(options?: CustomizeCloneOptions): ClassDecorator_<C>
+export function customizeClone<C extends Constructor>(
   semantics: 'deep', options?: CustomizeCloneOptions
 ): ClassDecorator_<C>
-export function customizeClone<C extends ConstructorFunc>(
+export function customizeClone<C extends Constructor>(
   semantics: 'iterate', options: IterateCloneOptions
 ): ClassDecorator_<C>
-export function customizeClone<C extends ConstructorFunc>(
+export function customizeClone<C extends Constructor>(
   semantics: 'returnOriginal' | 'errorOnClone'
 ): ClassDecorator_<C>
-export function customizeClone<C extends ConstructorFunc>(
+export function customizeClone<C extends Constructor>(
   semanticsOrOpts?: CloneSemantics | CustomizeCloneOptions, options?: CustomizeCloneOptions | IterateCloneOptions
 ): ClassDecorator_<C> {
   type I = InstanceType<C>;

--- a/lib/clone.ts
+++ b/lib/clone.ts
@@ -262,7 +262,7 @@ export function customizeClone<I extends object>(
     return this;
   }
 
-  function returnIterateMethBuilder(
+  function iterateMethBuilder(
     addMethod: PropKey, runConstructor?: boolean
   ): (visited: CloneVisited) => I {
     return function<M>(this: IterateClonable<I, M, typeof addMethod>, visited: CloneVisited): I {
@@ -278,7 +278,7 @@ export function customizeClone<I extends object>(
   return function(_constructor: Constructor<I>, context: ClassDecoratorContext): void {
     if (semantics === 'iterate') {
       const opts = options as IterateCloneOptions;
-      context.metadata[CLONE_METHOD] = returnIterateMethBuilder(opts.addMethod, opts.runConstructor);
+      context.metadata[CLONE_METHOD] = iterateMethBuilder(opts.addMethod, opts.runConstructor);
     } else if (semantics === 'returnOriginal') {
       context.metadata[CLONE_METHOD] = returnOriginalMeth;
     } else if (semantics === 'errorOnClone') {

--- a/lib/clone.ts
+++ b/lib/clone.ts
@@ -277,9 +277,15 @@ export function customizeClone<C extends Constructor>(
     }
   }
 
-  return function(_constructor: C, context: ClassDecoratorContext): void {
+  return function(constructor: C, context: ClassDecoratorContext): void {
     if (semantics === 'iterate') {
       const opts = options as IterateCloneOptions;
+      if (!(Symbol.iterator in constructor.prototype)) {
+        throw new ValueSemanticsError('IterateNonIterable');
+      }
+      if (!(opts.addMethod in constructor.prototype)) {
+        throw new ValueSemanticsError('IterateNoAddMethod');
+      }
       context.metadata[CLONE_METHOD] = iterateMethBuilder(opts.addMethod, opts.runConstructor);
     } else if (semantics === 'returnOriginal') {
       context.metadata[CLONE_METHOD] = returnOriginalMeth;

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -23,7 +23,7 @@ export function getMeta<T>(target: object, key: PropKey): T | typeof META_NOT_FO
 }
 
 export function setMeta(
-  target: ConstructorFunc | BigIntConstructor | SymbolConstructor, key: PropKey, value: unknown
+  target: Constructor | BigIntConstructor | SymbolConstructor, key: PropKey, value: unknown
 ): void {
   target[Symbol.metadata] ??= {};
   target[Symbol.metadata]![key] = value;
@@ -106,9 +106,7 @@ export function getKeys(
 
 // * Customization: Decorators *
 
-export type Constructor<Instance> = { new(...args: any[]): Instance; };
-
-export type ConstructorFunc = abstract new (...args: any) => any;
+export type Constructor = abstract new (...args: any) => any;
 
 export type ClassDecorator_<C> = (
   constructor: C, context: ClassDecoratorContext

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -114,11 +114,14 @@ export type ClassDecorator_<C> = (
 
 // * Errors *
 
-export type ValueSemanticsErrorType = 'ErrorOnClone' | 'IncludeAndExclude';
+export type ValueSemanticsErrorType = 'ErrorOnClone' | 'IncludeAndExclude' | 'IterateNonIterable'
+  | 'IterateNoAddMethod';
 
 export const ERROR_MSGS: Record<ValueSemanticsErrorType, string> = {
   'ErrorOnClone': 'Instances of class % cannot be cloned',
-  'IncludeAndExclude': 'A field cannot be decorated with both `@include` and `@exclude`'
+  'IncludeAndExclude': 'A field cannot be decorated with both `@include` and `@exclude`',
+  'IterateNonIterable': "A non-iterable class cannot be decorated with 'iterate' semantics",
+  'IterateNoAddMethod': 'The specified `addMethod` does not exist on this class'
 }
 
 export class ValueSemanticsError extends Error {

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -108,9 +108,13 @@ export function getKeys(
 
 export type Constructor<Instance> = { new(...args: any[]): Instance; };
 
-export type ClassDecorator_<I> = (
+export type ClassDecoratorInst<I> = (
   constructor: Constructor<I>, context: ClassDecoratorContext
 ) => Constructor<I> | void;
+
+export type ClassDecorator_<C> = (
+  constructor: C, context: ClassDecoratorContext
+) => C | void;
 
 // * Errors *
 

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -23,7 +23,7 @@ export function getMeta<T>(target: object, key: PropKey): T | typeof META_NOT_FO
 }
 
 export function setMeta(
-  target: Constructor<unknown> | BigIntConstructor | SymbolConstructor, key: PropKey, value: unknown
+  target: ConstructorFunc | BigIntConstructor | SymbolConstructor, key: PropKey, value: unknown
 ): void {
   target[Symbol.metadata] ??= {};
   target[Symbol.metadata]![key] = value;
@@ -108,9 +108,7 @@ export function getKeys(
 
 export type Constructor<Instance> = { new(...args: any[]): Instance; };
 
-export type ClassDecoratorInst<I> = (
-  constructor: Constructor<I>, context: ClassDecoratorContext
-) => Constructor<I> | void;
+export type ConstructorFunc = abstract new (...args: any) => any;
 
 export type ClassDecorator_<C> = (
   constructor: C, context: ClassDecoratorContext

--- a/lib/equals.ts
+++ b/lib/equals.ts
@@ -94,6 +94,10 @@ function checkExactPrototype<C extends Constructor>(
   return Object.getPrototypeOf(subject) === constructor.prototype;
 }
 
+function checkSamePrototype<L extends object>(lhs: L, rhs: unknown): rhs is L {
+  return Object.getPrototypeOf(lhs) === Object.getPrototypeOf(rhs);
+}
+
 function wrappedPrimitiveEquals(obj: object, prim: unknown): boolean {
   for (const Wrapped of WrappedPrimitives) {
       if (obj instanceof Wrapped) {
@@ -137,7 +141,7 @@ function checkMapMembers(
 defineEqualsMethod(
   Array, 
   function(this: unknown[], other: object, visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, Array)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     if (this.length !== other.length) {
@@ -150,7 +154,7 @@ defineEqualsMethod(
 defineEqualsMethod(
   Set, 
   function(this: Set<unknown>, other: object, visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, Set)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     if (this.size !== other.size) {
@@ -163,7 +167,7 @@ defineEqualsMethod(
 defineEqualsMethod(
   Map, 
   function(this: Map<unknown, unknown>, other: object, visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, Map)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     if (this.size !== other.size) {
@@ -176,7 +180,7 @@ defineEqualsMethod(
 defineEqualsMethod(
   RegExp, 
   function(this: RegExp, other: object, _visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, RegExp)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     return this.toString() === other.toString();
@@ -186,7 +190,7 @@ defineEqualsMethod(
 defineEqualsMethod(
   Date, 
   function(this: Date, other: object, _visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, Date)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     return +this === +other;
@@ -196,7 +200,7 @@ defineEqualsMethod(
 defineEqualsMethod(
   ArrayBuffer, 
   function(this: ArrayBuffer, other: object, _visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, ArrayBuffer)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     if (this.byteLength !== other.byteLength) {
@@ -216,7 +220,7 @@ defineEqualsMethod(
 defineEqualsMethod(
   SharedArrayBuffer, 
   function(this: SharedArrayBuffer, other: object, _visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, SharedArrayBuffer)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     if (this.byteLength !== other.byteLength) {
@@ -236,7 +240,7 @@ defineEqualsMethod(
 defineEqualsMethod(
   DataView, 
   function(this: DataView, other: object, _visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, DataView)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     if (this.byteLength !== other.byteLength) {
@@ -255,7 +259,7 @@ for (const typedArray of TYPED_ARRAYS) {
   defineEqualsMethod(
     typedArray, 
     function(this: InstanceType<typeof typedArray>, other: object, _visited: EqualsVisited): boolean {
-      if (!checkExactPrototype(other, typedArray)) {
+      if (!checkSamePrototype(this, other)) {
         return false;
       }
       if (this.byteLength !== other.byteLength) {
@@ -274,7 +278,7 @@ for (const typedArray of TYPED_ARRAYS) {
 defineEqualsMethod(
   WeakRef, 
   function(this: WeakRef<WeakKey>, other: object, visited: EqualsVisited): boolean {
-    if (!checkExactPrototype(other, WeakRef)) {
+    if (!checkSamePrototype(this, other)) {
       return false;
     }
     return equalscyc(this.deref(), other.deref(), visited);

--- a/lib/equals.ts
+++ b/lib/equals.ts
@@ -8,7 +8,7 @@
 
 import { EQUALS_EXCLUDE_PROPS, EQUALS_INCLUDE_PROPS, EqualsVisited, EQUALS_METHOD, TYPED_ARRAYS, 
   getAllKeys, getKeys, PropKey, EqualMethodFunc, setMeta, getMeta, META_NOT_FOUND, Constructor, 
-  ClassDecorator_ } from "./common";
+  ClassDecorator_, ValueSemanticsError} from "./common";
 
 // * Helpers *
 
@@ -412,7 +412,7 @@ export function customizeEquals<C extends Constructor>(
   }
   const opts: Required<CustomizeEqualsOptions> = { propDefault: 'include', ...options };
 
-  return function(_constructor: C, context: ClassDecoratorContext): void {
+  return function(constructor: C, context: ClassDecoratorContext): void {
     if (semantics === 'ref') {
       context.metadata[REF_EQUALS] = true;
       return;
@@ -462,6 +462,9 @@ export function customizeEquals<C extends Constructor>(
     };
 
     if (semantics === 'iterate') {
+      if (!(Symbol.iterator in constructor.prototype)) {
+        throw new ValueSemanticsError('IterateNonIterable');
+      }
       context.metadata[EQUALS_METHOD] = iterateEqualsMeth;
     } else {
       context.metadata[EQUALS_METHOD] = valueEqualsMeth;

--- a/lib/equals.ts
+++ b/lib/equals.ts
@@ -7,7 +7,7 @@
 // * Imports *
 
 import { EQUALS_EXCLUDE_PROPS, EQUALS_INCLUDE_PROPS, EqualsVisited, EQUALS_METHOD, TYPED_ARRAYS, 
-  getAllKeys, getKeys, PropKey, EqualMethodFunc, setMeta, getMeta, META_NOT_FOUND, ConstructorFunc, 
+  getAllKeys, getKeys, PropKey, EqualMethodFunc, setMeta, getMeta, META_NOT_FOUND, Constructor, 
   ClassDecorator_ } from "./common";
 
 // * Helpers *
@@ -76,19 +76,19 @@ function setVisited(fst: object, snd: object, visited: EqualsVisited, res: boole
 
 // Definition Helpers
 
-const defineEqualsMethod = <C extends ConstructorFunc>(
+const defineEqualsMethod = <C extends Constructor>(
   target: C, value: EqualMethodFunc<InstanceType<C>>
 ) => {
   setMeta(target, EQUALS_METHOD, value);
 };
 
-const defineRefEquals = (target: ConstructorFunc) => {
+const defineRefEquals = (target: Constructor) => {
   setMeta(target, REF_EQUALS, true);
 };
 
 // Equality Helpers
 
-function checkExactPrototype<C extends ConstructorFunc>(
+function checkExactPrototype<C extends Constructor>(
   subject: unknown, constructor: C
 ): subject is InstanceType<C> {
   return Object.getPrototypeOf(subject) === constructor.prototype;
@@ -384,15 +384,15 @@ function checkExactSamePrototype<I>(lhs: I, rhs: unknown): rhs is I {
 
 // Class Decorator
 
-export function customizeEquals<C extends ConstructorFunc>(
+export function customizeEquals<C extends Constructor>(
   options?: CustomizeEqualsOptions
 ): ClassDecorator_<C>
-export function customizeEquals<C extends ConstructorFunc>(
+export function customizeEquals<C extends Constructor>(
   semantics: 'value', options?: CustomizeEqualsOptions
 ): ClassDecorator_<C>
-export function customizeEquals<C extends ConstructorFunc>(semantics: 'ref'): ClassDecorator_<C>
-export function customizeEquals<C extends ConstructorFunc>(semantics: 'iterate'): ClassDecorator_<C>
-export function customizeEquals<C extends ConstructorFunc>(
+export function customizeEquals<C extends Constructor>(semantics: 'ref'): ClassDecorator_<C>
+export function customizeEquals<C extends Constructor>(semantics: 'iterate'): ClassDecorator_<C>
+export function customizeEquals<C extends Constructor>(
   semanticsOrOpts?: EqualsSemantics | CustomizeEqualsOptions, options?: CustomizeEqualsOptions
 ): ClassDecorator_<C> {
   type I = InstanceType<C>;

--- a/lib/equals.ts
+++ b/lib/equals.ts
@@ -6,7 +6,7 @@
 
 // * Imports *
 
-import { Constructor, EQUALS_EXCLUDE_PROPS, EQUALS_INCLUDE_PROPS, ClassDecorator_, EqualsVisited, 
+import { Constructor, EQUALS_EXCLUDE_PROPS, EQUALS_INCLUDE_PROPS, ClassDecoratorInst, EqualsVisited, 
   EQUALS_METHOD, TYPED_ARRAYS, getAllKeys, getKeys, PropKey, EqualMethodFunc, setMeta, getMeta, 
   META_NOT_FOUND } from "./common";
 
@@ -384,15 +384,15 @@ function checkExactSamePrototype<I>(lhs: I, rhs: unknown): rhs is I {
 
 // Class Decorator
 
-export function customizeEquals<I extends object>(options?: CustomizeEqualsOptions): ClassDecorator_<I>
+export function customizeEquals<I extends object>(options?: CustomizeEqualsOptions): ClassDecoratorInst<I>
 export function customizeEquals<I extends object>(
   semantics: 'value', options?: CustomizeEqualsOptions
-): ClassDecorator_<I>
-export function customizeEquals<I extends object>(semantics: 'ref'): ClassDecorator_<I>
-export function customizeEquals<I extends object>(semantics: 'iterate'): ClassDecorator_<I>
+): ClassDecoratorInst<I>
+export function customizeEquals<I extends object>(semantics: 'ref'): ClassDecoratorInst<I>
+export function customizeEquals<I extends object>(semantics: 'iterate'): ClassDecoratorInst<I>
 export function customizeEquals<I extends object>(
   semanticsOrOpts?: EqualsSemantics | CustomizeEqualsOptions, options?: CustomizeEqualsOptions
-): ClassDecorator_<I> {
+): ClassDecoratorInst<I> {
   const semantics: EqualsSemantics = typeof semanticsOrOpts === 'string' ? semanticsOrOpts : 'value';
   
   if (!options) {

--- a/lib/equals.ts
+++ b/lib/equals.ts
@@ -88,12 +88,6 @@ const defineRefEquals = (target: Constructor) => {
 
 // Equality Helpers
 
-function checkExactPrototype<C extends Constructor>(
-  subject: unknown, constructor: C
-): subject is InstanceType<C> {
-  return Object.getPrototypeOf(subject) === constructor.prototype;
-}
-
 function checkSamePrototype<L extends object>(lhs: L, rhs: unknown): rhs is L {
   return Object.getPrototypeOf(lhs) === Object.getPrototypeOf(rhs);
 }
@@ -347,7 +341,7 @@ export function equalscyc(lhs: unknown, rhs: unknown, visited: EqualsVisited): b
     }
   }
   // Other Objects
-  if (Object.getPrototypeOf(lhs) !== Object.getPrototypeOf(rhs)) {
+  if (!checkSamePrototype(lhs, rhs)) {
     setVisited(lhs, rhs, visited, false);
     return false;
   }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -5,7 +5,7 @@
 // * Value-Semantics: The JavaScript/TypeScript Value Semantics Toolkit *
 
 import { CLONE_SEMANTICS, CloneSemantics, customizeClone, CustomizeCloneOptions, clone } from './clone';
-import { ClassDecorator_, ConstructorFunc } from './common';
+import { ClassDecorator_, Constructor } from './common';
 import { customizeEquals, CustomizeEqualsOptions, EQUALS_SEMANTICS, EqualsSemantics, equals } from './equals';
 
 export { clone } from './clone';
@@ -24,49 +24,49 @@ export namespace customize {
   export const clone = customizeClone;
   export const equals = customizeEquals;
 
-  export function value<C extends ConstructorFunc>(options?: CustomizeValueOptions): ClassDecorator_<C> // No Semantics
-  export function value<C extends ConstructorFunc>( // Clone Semantics
+  export function value<C extends Constructor>(options?: CustomizeValueOptions): ClassDecorator_<C> // No Semantics
+  export function value<C extends Constructor>( // Clone Semantics
     cloneSemantics: 'deep', options?: CustomizeValueOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>( // Equals Semantics
+  export function value<C extends Constructor>( // Equals Semantics
     equalsSemantics: 'value', options?: CustomizeValueOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     equalsSemantics: 'ref', options?: CustomizeCloneOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>( // Clone then Equals Semantics
+  export function value<C extends Constructor>( // Clone then Equals Semantics
     cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     equalsSemantics: 'value', 
     options?: CustomizeEqualsOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     equalsSemantics: 'ref'
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>( // Equals then Clone Semantics
+  export function value<C extends Constructor>( // Equals then Clone Semantics
     equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     equalsSemantics: 'value', 
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     options?: CustomizeEqualsOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>(
+  export function value<C extends Constructor>(
     equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone', 
   ): ClassDecorator_<C>
-  export function value<C extends ConstructorFunc>( // Overload
+  export function value<C extends Constructor>( // Overload
     first?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions, 
     second?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions,
     third?: CustomizeValueOptions

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -13,6 +13,9 @@ export { equals } from './equals';
 
 type CustomizeValueOptions = CustomizeCloneOptions;
 
+type CloneSemanticsWOIterate = 'deep' | 'returnOriginal' | 'errorOnClone';
+type EqualsSemanticsWOIterate = 'value' | 'ref';
+
 /**
  * Class decorators which allow the class' `equals` and `clone` implementations to be customized.
  * @public
@@ -64,32 +67,32 @@ export namespace customize {
     equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone', 
   ): ClassDecorator_<I>
   export function value<I extends object>( // Overload
-    first?: CloneSemantics | EqualsSemantics | CustomizeValueOptions, 
-    second?: CloneSemantics | EqualsSemantics | CustomizeValueOptions,
+    first?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions, 
+    second?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions,
     third?: CustomizeValueOptions
   ): ClassDecorator_<I> {
     return function(constructor: Constructor<I>, context: ClassDecoratorContext): void {
-      let cloneSemantics: CloneSemantics = 'deep';
-      let equalsSemantics: EqualsSemantics = 'value';
+      let cloneSemantics: CloneSemanticsWOIterate = 'deep';
+      let equalsSemantics: EqualsSemanticsWOIterate = 'value';
       let opts: CustomizeValueOptions = {};
 
       if (typeof first === 'string') {
-        if (CLONE_SEMANTICS.includes(first as CloneSemantics)) {
-          cloneSemantics = first as CloneSemantics;
+        if (CLONE_SEMANTICS.includes(first as CloneSemanticsWOIterate)) {
+          cloneSemantics = first as CloneSemanticsWOIterate;
         }
-        if (EQUALS_SEMANTICS.includes(first as EqualsSemantics)) {
-          equalsSemantics = first as EqualsSemantics;
+        if (EQUALS_SEMANTICS.includes(first as EqualsSemanticsWOIterate)) {
+          equalsSemantics = first as EqualsSemanticsWOIterate;
         }
       } else if (first) {
         opts = first;
       }
 
       if (typeof second === 'string') {
-        if (CLONE_SEMANTICS.includes(second as CloneSemantics)) {
-          cloneSemantics = second as CloneSemantics;
+        if (CLONE_SEMANTICS.includes(second as CloneSemanticsWOIterate)) {
+          cloneSemantics = second as CloneSemanticsWOIterate;
         }
-        if (EQUALS_SEMANTICS.includes(second as EqualsSemantics)) {
-          equalsSemantics = second as EqualsSemantics;
+        if (EQUALS_SEMANTICS.includes(second as EqualsSemanticsWOIterate)) {
+          equalsSemantics = second as EqualsSemanticsWOIterate;
         }
       } else if (second) {
         opts = second;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -5,7 +5,7 @@
 // * Value-Semantics: The JavaScript/TypeScript Value Semantics Toolkit *
 
 import { CLONE_SEMANTICS, CloneSemantics, customizeClone, CustomizeCloneOptions, clone } from './clone';
-import { ClassDecoratorInst, Constructor } from './common';
+import { ClassDecorator_, ConstructorFunc } from './common';
 import { customizeEquals, CustomizeEqualsOptions, EQUALS_SEMANTICS, EqualsSemantics, equals } from './equals';
 
 export { clone } from './clone';
@@ -24,54 +24,54 @@ export namespace customize {
   export const clone = customizeClone;
   export const equals = customizeEquals;
 
-  export function value<I extends object>(options?: CustomizeValueOptions): ClassDecoratorInst<I> // No Semantics
-  export function value<I extends object>( // Clone Semantics
+  export function value<C extends ConstructorFunc>(options?: CustomizeValueOptions): ClassDecorator_<C> // No Semantics
+  export function value<C extends ConstructorFunc>( // Clone Semantics
     cloneSemantics: 'deep', options?: CustomizeValueOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>( // Equals Semantics
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>( // Equals Semantics
     equalsSemantics: 'value', options?: CustomizeValueOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     equalsSemantics: 'ref', options?: CustomizeCloneOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>( // Clone then Equals Semantics
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>( // Clone then Equals Semantics
     cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     equalsSemantics: 'value', 
     options?: CustomizeEqualsOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     equalsSemantics: 'ref'
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>( // Equals then Clone Semantics
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>( // Equals then Clone Semantics
     equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     equalsSemantics: 'value', 
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     options?: CustomizeEqualsOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>(
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>(
     equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone', 
-  ): ClassDecoratorInst<I>
-  export function value<I extends object>( // Overload
+  ): ClassDecorator_<C>
+  export function value<C extends ConstructorFunc>( // Overload
     first?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions, 
     second?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions,
     third?: CustomizeValueOptions
-  ): ClassDecoratorInst<I> {
-    return function(constructor: Constructor<I>, context: ClassDecoratorContext): void {
+  ): ClassDecorator_<C> {
+    return function(constructor: C, context: ClassDecoratorContext): void {
       let cloneSemantics: CloneSemanticsWOIterate = 'deep';
       let equalsSemantics: EqualsSemanticsWOIterate = 'value';
       let opts: CustomizeValueOptions = {};

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -5,7 +5,7 @@
 // * Value-Semantics: The JavaScript/TypeScript Value Semantics Toolkit *
 
 import { CLONE_SEMANTICS, CloneSemantics, customizeClone, CustomizeCloneOptions, clone } from './clone';
-import { ClassDecorator_, Constructor } from './common';
+import { ClassDecoratorInst, Constructor } from './common';
 import { customizeEquals, CustomizeEqualsOptions, EQUALS_SEMANTICS, EqualsSemantics, equals } from './equals';
 
 export { clone } from './clone';
@@ -24,53 +24,53 @@ export namespace customize {
   export const clone = customizeClone;
   export const equals = customizeEquals;
 
-  export function value<I extends object>(options?: CustomizeValueOptions): ClassDecorator_<I> // No Semantics
+  export function value<I extends object>(options?: CustomizeValueOptions): ClassDecoratorInst<I> // No Semantics
   export function value<I extends object>( // Clone Semantics
     cloneSemantics: 'deep', options?: CustomizeValueOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>( // Equals Semantics
     equalsSemantics: 'value', options?: CustomizeValueOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     equalsSemantics: 'ref', options?: CustomizeCloneOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>( // Clone then Equals Semantics
     cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     equalsSemantics: 'value', 
     options?: CustomizeEqualsOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     equalsSemantics: 'ref'
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>( // Equals then Clone Semantics
     equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     equalsSemantics: 'value', 
     cloneSemantics: 'returnOriginal' | 'errorOnClone', 
     options?: CustomizeEqualsOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>(
     equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone', 
-  ): ClassDecorator_<I>
+  ): ClassDecoratorInst<I>
   export function value<I extends object>( // Overload
     first?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions, 
     second?: CloneSemanticsWOIterate | EqualsSemanticsWOIterate | CustomizeValueOptions,
     third?: CustomizeValueOptions
-  ): ClassDecorator_<I> {
+  ): ClassDecoratorInst<I> {
     return function(constructor: Constructor<I>, context: ClassDecoratorContext): void {
       let cloneSemantics: CloneSemanticsWOIterate = 'deep';
       let equalsSemantics: EqualsSemanticsWOIterate = 'value';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@vitest/coverage-v8": "^3.0.7",
         "istanbul-badges-readme": "^1.9.0",
         "typescript": "^5.8.2",
-        "vite": "^6.2.0"
+        "vite": "^6.2.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2498,9 +2498,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@microsoft/api-extractor": "^7.51.1",
         "@vitest/coverage-v8": "^3.0.7",
+        "istanbul-badges-readme": "^1.9.0",
         "typescript": "^5.8.2",
         "vite": "^6.2.0"
       }
@@ -1696,6 +1697,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-badges-readme": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/istanbul-badges-readme/-/istanbul-badges-readme-1.9.0.tgz",
+      "integrity": "sha512-sD9lTsFajcfK07euJReQ0C9dy0VmXViMDJk67EZseGRC+jv+esxt5I3Viqoi1b43m5in5ek5b+0rpxJi41bJVw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "istanbul-badges-readme": "lib/index.js"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "scripts": {
     "make-badges": "istanbul-badges-readme",
     "build": "tsc && vite build && api-extractor run --local --verbose",
+    "playground": "tsc ./dev/playground.cts && node ./dev/playground.cjs",
     "coverage": "vitest run --coverage",
     "test": "vitest",
     "pubalpha": "npm version prerelease --preid alpha && npm publish --tag alpha",
@@ -69,6 +70,6 @@
     "@vitest/coverage-v8": "^3.0.7",
     "istanbul-badges-readme": "^1.9.0",
     "typescript": "^5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "make-badges": "istanbul-badges-readme",
     "build": "tsc && vite build && api-extractor run --local --verbose",
-    "playground": "tsc ./dev/playground.cts && node ./dev/playground.cjs",
+    "playground": "tsc --project ./dev && node ./dev/playground.cjs",
     "coverage": "vitest run --coverage",
     "test": "vitest",
     "pubalpha": "npm version prerelease --preid alpha && npm publish --tag alpha",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lib": "lib"
   },
   "scripts": {
+    "make-badges": "istanbul-badges-readme",
     "build": "tsc && vite build && api-extractor run --local --verbose",
     "coverage": "vitest run --coverage",
     "test": "vitest",
@@ -66,6 +67,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.51.1",
     "@vitest/coverage-v8": "^3.0.7",
+    "istanbul-badges-readme": "^1.9.0",
     "typescript": "^5.8.2",
     "vite": "^6.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "make-badges": "istanbul-badges-readme",
     "build": "tsc && vite build && api-extractor run --local --verbose",
-    "playground": "tsc --project ./dev && node ./dev/playground.cjs",
+    "playground": "vite build --config ./dev/playground.vite.config.ts && node ./dev/build/playground.js",
     "coverage": "vitest run --coverage",
     "test": "vitest",
     "pubalpha": "npm version prerelease --preid alpha && npm publish --tag alpha",

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -339,6 +339,26 @@ test('constructorParams are implictly excluded', () => {
   expect(instanceClone.constructorField2).toBe(11);
 })
 
+
+test('class with iterate semantics', () => {
+  @customize.clone('iterate', { addMethod: 'add' })
+  class IterateExample {
+    constructor(public members: string[]) { }
+
+    [Symbol.iterator](): Iterator<string> {
+      return this.members[Symbol.iterator]();
+    }
+
+    add(member: string): void {
+      this.members.push(member);
+    }
+  }
+  const instance = new IterateExample(['a', 'b']);
+  const instanceClone = clone(instance);
+  expect(instanceClone instanceof IterateExample).toBeTruthy();
+  expect(instanceClone.members[0]).toBe('a');
+})
+
 // * Reference Cycles *
 
 test('clones an object literal containing a reference cycle', () => {

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -340,7 +340,7 @@ test('constructorParams are implictly excluded', () => {
 })
 
 
-test('class with iterate semantics', () => {
+test('clone class instance with iterate semantics', () => {
   @customize.clone('iterate', { runConstructor: true, addMethod: 'push' })
   class ArraySuperExample<M> extends Array<M> { }
   const arr = new ArraySuperExample(1, 2);

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { clone, customize } from '../lib/main'
+import { Constructor } from '../lib/common';
 
 // * Primitives *
 
@@ -341,16 +342,16 @@ test('constructorParams are implictly excluded', () => {
 
 
 test('class with iterate semantics', () => {
+  @customize.clone('iterate', { runConstructor: true, addMethod: 'push' })
+  class ArraySuperExample<M> extends Array<M> { }
+  const arr = new ArraySuperExample(1, 2);
+  const arrClone = clone(arr);
+  expect(arrClone instanceof ArraySuperExample).toBeTruthy();
+  expect(arrClone[1]).toBe(2);
+
   @customize.clone('iterate', { runConstructor: true, addMethod: 'add' })
   class IterateExample {
-    public members: string[];
-
-    constructor(members?: string[]) { 
-      this.members = [];
-      if (members) {
-        this.members = members;
-      }
-    }
+    public members: string[] = [];
 
     [Symbol.iterator](): Iterator<string> {
       return this.members[Symbol.iterator]();
@@ -360,7 +361,9 @@ test('class with iterate semantics', () => {
       this.members.push(member);
     }
   }
-  const instance = new IterateExample(['a', 'b']);
+  const instance = new IterateExample();
+  instance.add('a');
+  instance.add('b');
   const instanceClone = clone(instance);
   expect(instanceClone instanceof IterateExample).toBeTruthy();
   expect(instanceClone.members[0]).toBe('a');

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'vitest'
 import { clone, customize } from '../lib/main'
-import { Constructor } from '../lib/common';
 
 // * Primitives *
 

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -341,9 +341,16 @@ test('constructorParams are implictly excluded', () => {
 
 
 test('class with iterate semantics', () => {
-  @customize.clone('iterate', { addMethod: 'add' })
+  @customize.clone('iterate', { runConstructor: true, addMethod: 'add' })
   class IterateExample {
-    constructor(public members: string[]) { }
+    public members: string[];
+
+    constructor(members?: string[]) { 
+      this.members = [];
+      if (members) {
+        this.members = members;
+      }
+    }
 
     [Symbol.iterator](): Iterator<string> {
       return this.members[Symbol.iterator]();

--- a/test/equals.test.ts
+++ b/test/equals.test.ts
@@ -279,3 +279,23 @@ test('equating class instances with reference semantics', () => {
   const instanceR = new StrictEqualsExample();
   expect(equals(instanceL, instanceR)).toBeFalsy();
 })
+
+test('equating class instances with iterate semantics', () => {
+  @customize.equals('iterate')
+  class ArraySuperExample<M> extends Array<M> { }
+  const arr1 = new ArraySuperExample(1, 2);
+  const arr2 = new ArraySuperExample(1, 2);
+  expect(equals(arr1, arr2)).toBeTruthy();
+
+  @customize.equals('iterate')
+  class IterateExample {
+    constructor(public members: string[]) { };
+
+    [Symbol.iterator](): Iterator<string> {
+      return this.members[Symbol.iterator]();
+    }
+  }
+  const instance1 = new IterateExample(['a', 'b']);
+  const instance2 = new IterateExample(['a', 'b']);
+  expect(equals(instance1, instance2)).toBeTruthy();
+})

--- a/types/clone.d.ts
+++ b/types/clone.d.ts
@@ -1,4 +1,4 @@
-import { ClassDecorator_, PropKey, CloneVisited } from "./common";
+import { PropKey, CloneVisited, ClassDecorator_, ConstructorFunc } from "./common";
 export declare const ERROR_ON_CLONE: unique symbol;
 export declare function copyProps<T extends Object>(props: Set<PropKey>, target: T, source: T, visited: CloneVisited): void;
 /**
@@ -19,10 +19,10 @@ export type IterateCloneOptions = {
     addMethod: PropKey;
     runConstructor?: boolean;
 };
-export declare function customizeClone<I extends object>(options?: CustomizeCloneOptions): ClassDecorator_<I>;
-export declare function customizeClone<I extends object>(semantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<I>;
-export declare function customizeClone<I extends object>(semantics: 'iterate', options: IterateCloneOptions): ClassDecorator_<I>;
-export declare function customizeClone<I extends object>(semantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<I>;
+export declare function customizeClone<C extends ConstructorFunc>(options?: CustomizeCloneOptions): ClassDecorator_<C>;
+export declare function customizeClone<C extends ConstructorFunc>(semantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<C>;
+export declare function customizeClone<C extends ConstructorFunc>(semantics: 'iterate', options: IterateCloneOptions): ClassDecorator_<C>;
+export declare function customizeClone<C extends ConstructorFunc>(semantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<C>;
 /**
  * Class field decorators which allow the class' `clone` implementations to be customized.
  * @public

--- a/types/clone.d.ts
+++ b/types/clone.d.ts
@@ -1,4 +1,4 @@
-import { ClassDecorator, PropKey, CloneVisited } from "./common";
+import { ClassDecorator_, PropKey, CloneVisited } from "./common";
 export declare const ERROR_ON_CLONE: unique symbol;
 export declare function copyProps<T extends Object>(props: Set<PropKey>, target: T, source: T, visited: CloneVisited): void;
 /**
@@ -9,14 +9,20 @@ export declare function copyProps<T extends Object>(props: Set<PropKey>, target:
  */
 export declare function clone<T>(source: T): T;
 export declare function clonecyc<T>(source: T, visited: CloneVisited): T;
-export type CloneSemantics = 'deep' | 'returnOriginal' | 'errorOnClone';
+export declare const CLONE_SEMANTICS: readonly ["deep", "iterate", "returnOriginal", "errorOnClone"];
+export type CloneSemantics = typeof CLONE_SEMANTICS[number];
 export type CustomizeCloneOptions = {
     runConstructor?: boolean;
     propDefault?: 'include' | 'exclude';
 };
-export declare function customizeClone<I extends object>(options?: CustomizeCloneOptions): ClassDecorator<I>;
-export declare function customizeClone<I extends object>(semantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator<I>;
-export declare function customizeClone<I extends object>(semantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator<I>;
+export type IterateCloneOptions = {
+    addMethod: PropKey;
+    runConstructor?: boolean;
+};
+export declare function customizeClone<I extends object>(options?: CustomizeCloneOptions): ClassDecorator_<I>;
+export declare function customizeClone<I extends object>(semantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+export declare function customizeClone<I extends object>(semantics: 'iterate', options: IterateCloneOptions): ClassDecorator_<I>;
+export declare function customizeClone<I extends object>(semantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<I>;
 /**
  * Class field decorators which allow the class' `clone` implementations to be customized.
  * @public

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,6 +1,6 @@
 export declare const META_NOT_FOUND: unique symbol;
 export declare function getMeta<T>(target: object, key: PropKey): T | typeof META_NOT_FOUND;
-export declare function setMeta(target: Constructor<any> | BigIntConstructor | SymbolConstructor, key: PropKey, value: any): void;
+export declare function setMeta(target: Constructor<unknown> | BigIntConstructor | SymbolConstructor, key: PropKey, value: unknown): void;
 type TypedArrays = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;
 type TypedArrayConstructor = new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number) => TypedArrays;
 export declare const TYPED_ARRAYS: TypedArrayConstructor[];
@@ -22,7 +22,7 @@ export declare function getKeys(source: object, propDefault: PropDefault, derive
 export type Constructor<Instance> = {
     new (...args: any[]): Instance;
 };
-export type ClassDecorator<I> = (constructor: Constructor<I>, context: ClassDecoratorContext) => Constructor<I> | void;
+export type ClassDecorator_<I> = (constructor: Constructor<I>, context: ClassDecoratorContext) => Constructor<I> | void;
 export type ValueSemanticsErrorType = 'ErrorOnClone' | 'IncludeAndExclude';
 export declare const ERROR_MSGS: Record<ValueSemanticsErrorType, string>;
 export declare class ValueSemanticsError extends Error {

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,6 +1,6 @@
 export declare const META_NOT_FOUND: unique symbol;
 export declare function getMeta<T>(target: object, key: PropKey): T | typeof META_NOT_FOUND;
-export declare function setMeta(target: Constructor<unknown> | BigIntConstructor | SymbolConstructor, key: PropKey, value: unknown): void;
+export declare function setMeta(target: ConstructorFunc | BigIntConstructor | SymbolConstructor, key: PropKey, value: unknown): void;
 type TypedArrays = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;
 type TypedArrayConstructor = new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number) => TypedArrays;
 export declare const TYPED_ARRAYS: TypedArrayConstructor[];
@@ -22,7 +22,8 @@ export declare function getKeys(source: object, propDefault: PropDefault, derive
 export type Constructor<Instance> = {
     new (...args: any[]): Instance;
 };
-export type ClassDecorator_<I> = (constructor: Constructor<I>, context: ClassDecoratorContext) => Constructor<I> | void;
+export type ConstructorFunc = abstract new (...args: any) => any;
+export type ClassDecorator_<C> = (constructor: C, context: ClassDecoratorContext) => C | void;
 export type ValueSemanticsErrorType = 'ErrorOnClone' | 'IncludeAndExclude';
 export declare const ERROR_MSGS: Record<ValueSemanticsErrorType, string>;
 export declare class ValueSemanticsError extends Error {

--- a/types/equals.d.ts
+++ b/types/equals.d.ts
@@ -1,4 +1,4 @@
-import { ClassDecorator_, EqualsVisited } from "./common";
+import { EqualsVisited, ConstructorFunc, ClassDecorator_ } from "./common";
 export declare const REF_EQUALS: unique symbol;
 /**
  * Compares two values for value-equality.
@@ -14,10 +14,10 @@ export type EqualsSemantics = typeof EQUALS_SEMANTICS[number];
 export type CustomizeEqualsOptions = {
     propDefault?: 'include' | 'exclude';
 };
-export declare function customizeEquals<I extends object>(options?: CustomizeEqualsOptions): ClassDecorator_<I>;
-export declare function customizeEquals<I extends object>(semantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
-export declare function customizeEquals<I extends object>(semantics: 'ref'): ClassDecorator_<I>;
-export declare function customizeEquals<I extends object>(semantics: 'iterate'): ClassDecorator_<I>;
+export declare function customizeEquals<C extends ConstructorFunc>(options?: CustomizeEqualsOptions): ClassDecorator_<C>;
+export declare function customizeEquals<C extends ConstructorFunc>(semantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<C>;
+export declare function customizeEquals<C extends ConstructorFunc>(semantics: 'ref'): ClassDecorator_<C>;
+export declare function customizeEquals<C extends ConstructorFunc>(semantics: 'iterate'): ClassDecorator_<C>;
 /**
  * Class field decorators which allow the class' `equals` implementations to be customized.
  * @public

--- a/types/equals.d.ts
+++ b/types/equals.d.ts
@@ -1,4 +1,4 @@
-import { ClassDecorator, EqualsVisited } from "./common";
+import { ClassDecorator_, EqualsVisited } from "./common";
 export declare const REF_EQUALS: unique symbol;
 /**
  * Compares two values for value-equality.
@@ -9,13 +9,15 @@ export declare const REF_EQUALS: unique symbol;
  */
 export declare function equals(lhs: unknown, rhs: unknown): boolean;
 export declare function equalscyc(lhs: unknown, rhs: unknown, visited: EqualsVisited): boolean;
-export type EqualsSemantics = 'value' | 'ref';
+export declare const EQUALS_SEMANTICS: readonly ["value", "ref", "iterate"];
+export type EqualsSemantics = typeof EQUALS_SEMANTICS[number];
 export type CustomizeEqualsOptions = {
     propDefault?: 'include' | 'exclude';
 };
-export declare function customizeEquals<I extends object>(options?: CustomizeEqualsOptions): ClassDecorator<I>;
-export declare function customizeEquals<I extends object>(semantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator<I>;
-export declare function customizeEquals<I extends object>(semantics: 'ref'): ClassDecorator<I>;
+export declare function customizeEquals<I extends object>(options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+export declare function customizeEquals<I extends object>(semantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+export declare function customizeEquals<I extends object>(semantics: 'ref'): ClassDecorator_<I>;
+export declare function customizeEquals<I extends object>(semantics: 'iterate'): ClassDecorator_<I>;
 /**
  * Class field decorators which allow the class' `equals` implementations to be customized.
  * @public

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -1,7 +1,9 @@
-import { customizeClone } from './clone';
-import { customizeEquals } from './equals';
+import { customizeClone, CustomizeCloneOptions } from './clone';
+import { ClassDecorator_ } from './common';
+import { customizeEquals, CustomizeEqualsOptions } from './equals';
 export { clone } from './clone';
 export { equals } from './equals';
+type CustomizeValueOptions = CustomizeCloneOptions;
 /**
  * Class decorators which allow the class' `equals` and `clone` implementations to be customized.
  * @public
@@ -9,4 +11,25 @@ export { equals } from './equals';
 export declare namespace customize {
     const clone: typeof customizeClone;
     const equals: typeof customizeEquals;
+    function value<I extends object>(options?: CustomizeValueOptions): ClassDecorator_<I>;
+    function value<I extends object>(// Clone Semantics
+    cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    function value<I extends object>(// Equals Semantics
+    equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    function value<I extends object>(equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    function value<I extends object>(// Clone then Equals Semantics
+    cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    function value<I extends object>(cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'ref'): ClassDecorator_<I>;
+    function value<I extends object>(// Equals then Clone Semantics
+    equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
+    function value<I extends object>(equalsSemantics: 'value', cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
+    function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<I>;
+    function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<I>;
+}
+export declare namespace value {
+    function include<C, V>(target: undefined, context: ClassFieldDecoratorContext<C, V>): void;
+    function exclude<C, V>(target: undefined, context: ClassFieldDecoratorContext<C, V>): void;
 }

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -1,5 +1,5 @@
 import { customizeClone, CustomizeCloneOptions } from './clone';
-import { ClassDecorator_ } from './common';
+import { ClassDecorator_, ConstructorFunc } from './common';
 import { customizeEquals, CustomizeEqualsOptions } from './equals';
 export { clone } from './clone';
 export { equals } from './equals';
@@ -11,23 +11,23 @@ type CustomizeValueOptions = CustomizeCloneOptions;
 export declare namespace customize {
     const clone: typeof customizeClone;
     const equals: typeof customizeEquals;
-    function value<I extends object>(options?: CustomizeValueOptions): ClassDecorator_<I>;
-    function value<I extends object>(// Clone Semantics
-    cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
-    function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
-    function value<I extends object>(// Equals Semantics
-    equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
-    function value<I extends object>(equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
-    function value<I extends object>(// Clone then Equals Semantics
-    cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<I>;
-    function value<I extends object>(cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<I>;
-    function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
-    function value<I extends object>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'ref'): ClassDecorator_<I>;
-    function value<I extends object>(// Equals then Clone Semantics
-    equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<I>;
-    function value<I extends object>(equalsSemantics: 'value', cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<I>;
-    function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<I>;
-    function value<I extends object>(equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<I>;
+    function value<C extends ConstructorFunc>(options?: CustomizeValueOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(// Clone Semantics
+    cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(// Equals Semantics
+    equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(// Clone then Equals Semantics
+    cloneSemantics: 'deep', equalsSemantics: 'value', options?: CustomizeValueOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(cloneSemantics: 'deep', equalsSemantics: 'ref', options?: CustomizeCloneOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'value', options?: CustomizeEqualsOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(cloneSemantics: 'returnOriginal' | 'errorOnClone', equalsSemantics: 'ref'): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(// Equals then Clone Semantics
+    equalsSemantics: 'value', cloneSemantics: 'deep', options?: CustomizeValueOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(equalsSemantics: 'value', cloneSemantics: 'returnOriginal' | 'errorOnClone', options?: CustomizeEqualsOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(equalsSemantics: 'ref', cloneSemantics: 'deep', options?: CustomizeCloneOptions): ClassDecorator_<C>;
+    function value<C extends ConstructorFunc>(equalsSemantics: 'ref', cloneSemantics: 'returnOriginal' | 'errorOnClone'): ClassDecorator_<C>;
 }
 export declare namespace value {
     function include<C, V>(target: undefined, context: ClassFieldDecoratorContext<C, V>): void;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   test: {
     coverage: {
-      reporter: ['html', 'json-summary'],
+      reporter: ['text', 'html', 'clover', 'json', 'json-summary'],
     },
   },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   build: {
@@ -6,5 +6,10 @@ export default defineConfig({
       entry: './lib/main.ts',
       formats: [ 'es' ]
     }
-  }
+  },
+  test: {
+    coverage: {
+      reporter: ['html', 'json-summary'],
+    },
+  },
 })


### PR DESCRIPTION
Implements 'iterate' semantics for `clone` and `equals`.

Also added a development playground.
